### PR TITLE
Better support for async methods

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -36,4 +36,7 @@ declare module 'meteor/bhunjadi:mongo-transactions' {
     class CallbackError extends Error {
         callbackErrors: unknown[];
     }
+
+    function setDefaultOptions(options: RunInTransactionOptions): void;
+    function getDefaultOptions(): RunInTransactionOptions;
 }

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -4,12 +4,36 @@ declare module 'meteor/bhunjadi:mongo-transactions' {
     interface RunInTransactionOptions {
         sessionOptions?: SessionOptions;
         transactionOptions?: TransactionOptions;
+        // when true, using session.withTransaction which retries transaction callback or commit operation (whichever failed)
+        // see: https://mongodb.github.io/node-mongodb-native/3.6/api/ClientSession.html#withTransaction
         retry?: boolean;
+
+        // Should runInTransaction function wait for all async callbacks, for example Meteor.insert({}, callback);
+        // Might be useful if cache is used.
+        waitForCallbacks?: boolean;
+        // Whether runInTransaction should catch async functions errors. 
+        // True value only makes sense if waitForCallbacks is true.
+        // If there are any errors, runInTransaction will throw an error.
+        catchCallbackErrors?: boolean;
     }
 
     type TransactionCallback<R> = (session: ClientSession) => R;
 
-    const sessionVariable: Meteor.EnvironmentVariable<ClientSession | undefined>;
+    interface SessionContext {
+        session: ClientSession;
+        // waitForCallbacks: boolean;
+        catchCallbackErrors: boolean;
+    
+        callbackCount: number;
+        callbackErrors: unknown[];
+        resolveCallbacks();
+    }
+
+    const sessionVariable: Meteor.EnvironmentVariable<SessionContext | undefined>;
     function runInTransaction<R>(fn: TransactionCallback<R>, options?: RunInTransactionOptions): R;
     function isInTransaction(): boolean;
+
+    class CallbackError extends Error {
+        callbackErrors: unknown[];
+    }
 }

--- a/@types/mongo.d.ts
+++ b/@types/mongo.d.ts
@@ -7,5 +7,7 @@ declare module 'meteor/mongo' {
                 prototype: Record<string, any>;
             };
         };
+
+        var Connection: any;
     }    
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,17 @@ function runWithRetry<R>(context: SessionContext, fn: TransactionCallback<R>, op
     return result;
 }
 
-export function runInTransaction<R>(fn: TransactionCallback<R>, options: RunInTransactionOptions = {}): R {
+let defaultOptions: RunInTransactionOptions = {};
+
+export function setDefaultOptions(options: RunInTransactionOptions) {
+    defaultOptions = options;
+}
+
+export function getDefaultOptions(): RunInTransactionOptions {
+    return defaultOptions;
+}
+
+export function runInTransaction<R>(fn: TransactionCallback<R>, options: RunInTransactionOptions = defaultOptions): R {
     if (sessionVariable.get()) {
         throw new Error('Nested transactions are not supported');
     }

--- a/tests/client/index.ts
+++ b/tests/client/index.ts
@@ -108,7 +108,7 @@ describe('Client side testing', function () {
                 expect(_.pluck(clientItems, '_id')).to.be.eql(itemIds);
             }
         }
-    }).timeout(6000);
+    }).timeout(10000);
 
     async function runConcurrentTransactions(invoiceId) {
         const conn1 = createConnection();

--- a/tests/collections.ts
+++ b/tests/collections.ts
@@ -1,11 +1,12 @@
 export const Invoice = new Mongo.Collection<any>('invoice');
 export const InvoiceItem = new Mongo.Collection<any>('invoice_item');
+export const InvoiceLog = new Mongo.Collection<any>('invoice_log');
 
 // the thing with transactions is that they do throw errors when collection does NOT exist
 // example: BulkWriteError: Cannot create namespace meteor.invoice in multi-document transaction.
 
 // this forces creationg of all collections OUTSIDE of transaction
-[Invoice, InvoiceItem].forEach(collection => {
+[Invoice, InvoiceItem, InvoiceLog].forEach(collection => {
     collection.insert({});
 });
 


### PR DESCRIPTION
Idea here is to remove limitations of this package related to async callbacks in Meteor.

Both of these should now work (see tests inside this PR):
```
runInTransaction(() => {
    Invoice.insert({}, () => {
        InvoiceItem.insert({});
    })
    throw new Error('fail');
}, {
  waitForCallbacks: true,
});
```

and 

```
runInTransaction(() => {
    Invoice.insert({}, (err, res) => {
        InvoiceItem.insert({});
        throw new Error('fail');
    });

    // with or without it, transaction won't be aborted
    Meteor._sleepForMs(1000);
}, {
  waitForCallbacks: true,
  catchCallbackErrors: true,
});
```

There are two new parameters:

`waitForCallbacks: boolean`
This means that `runInTransaction` will wait for all callbacks to finish and then commit the transaction. This is implemented with a simple counter of callbacks inside the `EnvironmentVariable` value for each transaction.


`catchCallbackErrors: boolean`
Catches all  async callback errors and stores them in `EnvironmentVariable`. This is implemented by overriding `Meteor.bindEnvironment`. 


